### PR TITLE
Update for PHP 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Award Winning open source seo control panel for managing search engine optimi
 
 ## Requirements
 
-   1. PHP, MYSQL, Web Server(e.g APACHE)
+   1. PHP 8.0 or later, MYSQL, Web Server(e.g APACHE)
 
    2. CURL enabled with PHP, Refer following link to install curl with php if it is not installed.
 

--- a/install/db.class.php
+++ b/install/db.class.php
@@ -26,56 +26,61 @@ class DB{
 	var $connectionId = false; 	# db connectio id
 	var $error = false;   		# error while databse operations
 	
-	function connectDatabase($dbServer, $dbUser, $dbPassword, $dbName){
-		$this->connectionId = @mysql_connect($dbServer, $dbUser, $dbPassword, true);
-		if (!$this->connectionId){
-			return $this->getError();
-		}
-		return $this->selectDatabase($dbName);
-	}
+        function connectDatabase($dbServer, $dbUser, $dbPassword, $dbName){
+                $this->connectionId = @mysqli_connect($dbServer, $dbUser, $dbPassword, $dbName);
+                if (!$this->connectionId){
+                        $this->error = true;
+                        return $this->getError();
+                }
 
-	# func to select database
-	function selectDatabase($dbName){
-		$res = @mysql_select_db($dbName, $this->connectionId);
-		if(@mysql_errno() != 0){			
-			return $this->getError();
-		}
-	}
+                return true;
+        }
 
-	# func to Execute a general mysql query
-	function query($query, $noRows=false){
-		$res = @mysql_query($query, $this->connectionId);
-		if (empty($res)){
-			return $this->getError();
-		}
-		return $res;
-	}
-	
+        # func to select database
+        function selectDatabase($dbName){
+                $res = @mysqli_select_db($this->connectionId, $dbName);
+                if(@mysqli_errno($this->connectionId) != 0){
+                        return $this->getError();
+                }
+        }
+
+        # func to Execute a general mysql query
+        function query($query, $noRows=false){
+                $res = @mysqli_query($this->connectionId, $query);
+                if (empty($res)){
+                        return $this->getError();
+                }
+                return $res;
+        }
+
     #func to execute a select query
-	function select($query, $fetchFirst = false){
-		$res = @mysql_query($query, $this->connectionId);
-		if (!$res){
-			return false;
-		}
-		$returnArr = array();
-		while ($row = mysql_fetch_assoc($res)){
-			$returnArr[] = $row;
-		}
-		mysql_free_result($res);
-		if ($fetchFirst){
-			return $returnArr[0];
-		}
-		return $returnArr;
-	}
+        function select($query, $fetchFirst = false){
+                $res = @mysqli_query($this->connectionId, $query);
+                if (!$res){
+                        return false;
+                }
+                $returnArr = array();
+                while ($row = mysqli_fetch_assoc($res)){
+                        $returnArr[] = $row;
+                }
+                mysqli_free_result($res);
+                if ($fetchFirst){
+                        return $returnArr[0];
+                }
+                return $returnArr;
+        }
 
-	# func to Display the Mysql error
-	function getError(){
-		if (@mysql_errno() != 0) {			
-			$this->error = true;
-			$error =  "Mysql Error: " . @mysql_error();
-		}
-		return $error;
-	}
+        # func to Display the Mysql error
+        function getError(){
+                if (@mysqli_errno($this->connectionId) != 0) {
+                        $this->error = true;
+                        $error =  "Mysql Error: " . @mysqli_error($this->connectionId);
+                } else if (!$this->connectionId) {
+                        $this->error = true;
+                        $error =  "Mysql Error: " . mysqli_connect_error();
+                }
+                return $error;
+        }
 	
 	function importDatabaseFile($filename, $block=true){
 		

--- a/install/install.class.php
+++ b/install/install.class.php
@@ -28,11 +28,11 @@ class Install {
 		$phpClass = "red";
 		$phpSupport = "No";
 		$phpVersion = phpversion();
-		if (intval($phpVersion) >= 5) {			
-			$phpClass = "green";
-			$phpSupport = "Yes";
-		}
-		$phpSupport .= " ( PHP $phpVersion )";
+                if (intval($phpVersion) >= 8) {
+                        $phpClass = "green";
+                        $phpSupport = "Yes";
+                }
+                $phpSupport .= " ( PHP $phpVersion )";
 		
 		$mysqlClass = "red";
 		$mysqlSupport = "No";
@@ -107,7 +107,7 @@ class Install {
 			<tr><th colspan="2" class="header">Installation compatibility</th></tr>
 			<tr><td colspan="2" class="error"><?php echo $errMsg;?></td></tr>
 			<tr>
-				<th>PHP version >= 5.4.0</th>
+                                <th>PHP version >= 8.0.0</th>
 				<td class="<?php echo $phpClass;?>"><?php echo $phpSupport;?></td>
 			</tr>
 			<tr>
@@ -494,7 +494,7 @@ class Install {
 			<tr><th colspan="2" class="header">Upgrade compatibility</th></tr>
 			<tr><td colspan="2" class="error"><?php echo $errMsg;?></td></tr>
 			<tr>
-				<th>PHP version >= 5.4.0</th>
+                                <th>PHP version >= 8.0.0</th>
 				<td class="<?php echo $phpClass;?>"><?php echo $phpSupport;?></td>
 			</tr>
 			<tr>

--- a/libs/pchart.class.php
+++ b/libs/pchart.class.php
@@ -195,7 +195,7 @@
          $buffer = fgets($handle, 4096);
          $buffer = str_replace(chr(10),"",$buffer);
          $buffer = str_replace(chr(13),"",$buffer);
-         $Values = split($Delimiter,$buffer);
+         $Values = explode($Delimiter, $buffer);
          if ( count($Values) == 3 )
           {
            $this->Palette[$ColorID]["R"] = $Values[0];

--- a/libs/pdata.class.php
+++ b/libs/pdata.class.php
@@ -71,7 +71,7 @@
          $buffer = fgets($handle, 4096);
          $buffer = str_replace(chr(10),"",$buffer);
          $buffer = str_replace(chr(13),"",$buffer);
-         $Values = split($Delimiter,$buffer);
+         $Values = explode($Delimiter, $buffer);
 
          if ( $buffer != "" )
           {


### PR DESCRIPTION
## Summary
- update CSV parsers to use `explode()` instead of removed `split()`
- migrate installer database helper to mysqli
- check for PHP 8 during install and update compatibility text
- note PHP 8 requirement in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684385e316848323829c1a4802762a70