### PR TITLE
Fix typos across the codebase

### DIFF
--- a/api/keyword.api.php
+++ b/api/keyword.api.php
@@ -90,7 +90,7 @@ class KeywordAPI extends Seopanel{
 	 * 		$info['id']  		The id of the keyword	- Mandatory
 	 * 		$info['from_time']  	The from time of report in (yyyy-mm-dd) Eg: 2014-12-24	- Optional - (default => Yesterday)
 	 * 		$info['to_time']  		The to time of report in (yyyy-mm-dd) Eg: 2014-12-28	- Optional - (default => Today)
-	 * @return Array $returnInfo  	Contains informations about keyword reports
+	 * @return Array $returnInfo  	Contains information about keyword reports
 	 */
 	function getReportById($info) {
 		
@@ -118,7 +118,7 @@ class KeywordAPI extends Seopanel{
 	 * 		$info['id']  			The id of the website	- Mandatory
 	 * 		$info['from_time']  	The from time of report in (yyyy-mm-dd) Eg: 2014-12-24	- Optional - (default => Yesterday)
 	 * 		$info['to_time']  		The to time of report in (yyyy-mm-dd) Eg: 2014-12-28	- Optional - (default => Today)
-	 * @return Array $returnInfo  	Contains informations about keyword reports
+	 * @return Array $returnInfo  	Contains information about keyword reports
 	 */
 	function getReportByWebsiteId($info) {
 		
@@ -159,7 +159,7 @@ class KeywordAPI extends Seopanel{
 	 * 		$info['id']  			The id of the user	- Mandatory
 	 * 		$info['from_time']  	The from time of report in (yyyy-mm-dd) Eg: 2014-12-24	- Optional - (default => Yesterday)
 	 * 		$info['to_time']  		The to time of report in (yyyy-mm-dd) Eg: 2014-12-28	- Optional - (default => Today)
-	 * @return Array $returnInfo  	Contains informations about keyword reports
+	 * @return Array $returnInfo  	Contains information about keyword reports
 	 */
 	function getReportByUserId($info) {
 		
@@ -207,7 +207,7 @@ class KeywordAPI extends Seopanel{
 	 * function to get keyword information
 	 * @param Array $info			The input details to process the api
 	 * 		$info['id']  		    The id of the keyword	- Mandatory
-	 * @return Array $returnInfo  	Contains informations about keyword
+	 * @return Array $returnInfo  	Contains information about keyword
 	 */
 	function getKeywordInfo($info) {
 		$keywordId = intval($info['id']);
@@ -233,7 +233,7 @@ class KeywordAPI extends Seopanel{
 	 * 		$info['id']  		    The id of the website	- Mandatory
 	 * 		$info['status']  		The status of the keyword
 	 * 		$info['search']  		The search keyword
-	 * @return Array $returnInfo  	Contains informations about keyword
+	 * @return Array $returnInfo  	Contains information about keyword
 	 */
 	function getWebsiteKeywords($info) {
 	    $websiteId = intval($info['id']);

--- a/controllers/api.ctrl.php
+++ b/controllers/api.ctrl.php
@@ -39,7 +39,7 @@ class APIController extends Controller {
 		$this->render('api/showapiconnect');
 	}
 	
-	// get api credentails of the system
+	// get api credentials of the system
 	function getAPICredentials() {
 		$apiCredInfo =  array();
 		$settingCtrler = new SettingsController();

--- a/controllers/directory.ctrl.php
+++ b/controllers/directory.ctrl.php
@@ -539,7 +539,7 @@ class DirectoryController extends Controller{
 		$this->render('directory/skippeddirs');	
 	}
 	
-	# func to show submision reports
+	# func to show submission reports
 	function showSubmissionReports($searchInfo=''){
 		
 		$userId = isLoggedIn();		

--- a/controllers/proxy.ctrl.php
+++ b/controllers/proxy.ctrl.php
@@ -71,7 +71,7 @@ class ProxyController extends Controller{
 		$this->render('proxy/importproxy');
 	}
 	
-	#funvtion to import proxy
+	#function to import proxy
 	function importProxy($data = "") {
 		$errMsg['proxy_list'] = formatErrorMsg($this->validate->checkBlank($data['proxy_list']));
 		if(!$this->validate->flagErr){

--- a/controllers/seoplugins.ctrl.php
+++ b/controllers/seoplugins.ctrl.php
@@ -98,7 +98,7 @@ class SeoPluginsController extends Controller{
 		}
 	}
 	
-	# function to get plugin view path, chekc for theme exists or not
+	# function to get plugin view path, check for theme exists or not
 	function getPluginViewPath($pluginPath) {
 		$pluginViewPath = $pluginPath."/views";
 		

--- a/install/db.class.php
+++ b/install/db.class.php
@@ -24,7 +24,7 @@
 class DB{
 
 	var $connectionId = false; 	# db connectio id
-	var $error = false;   		# error while databse operations
+	var $error = false;   		# error while database operations
 	
         function connectDatabase($dbServer, $dbUser, $dbPassword, $dbName){
                 $this->connectionId = @mysqli_connect($dbServer, $dbUser, $dbPassword, $dbName);

--- a/install/index.php
+++ b/install/index.php
@@ -29,7 +29,7 @@ error_reporting(0);
 
 $install = New Install();
 
-# installation configiration
+# installation configuration
 define("SP_INSTALL_DIR", getcwd());
 define("SP_CONFIG_FILE", "config/sp-config.php");
 define("SP_CONFIG_FILE_EXTRA", "config/sp-config-extra.php");

--- a/login.php
+++ b/login.php
@@ -30,7 +30,7 @@ $controller->view->menu = 'login';
 $custSiteInfo = getCustomizerDetails();
 $siteName = !empty($custSiteInfo['site_name']) ? $custSiteInfo['site_name'] : "Seo Panel";
 $controller->set('spTitle', "$siteName: Login section");
-$controller->set('spDescription', "Login to $siteName and utilise seo tools and plugins to increase the perfomance of your site.");
+$controller->set('spDescription', "Login to $siteName and utilise seo tools and plugins to increase the performance of your site.");
 $controller->set('spKeywords', "$siteName Login section");
 
 if($_SERVER['REQUEST_METHOD'] == 'POST'){

--- a/seo-plugins.php
+++ b/seo-plugins.php
@@ -32,8 +32,8 @@ $controller->set('spTextPlugin', $controller->spTextPlugin);
 // set site details according to customizer plugin
 $custSiteInfo = getCustomizerDetails();
 $siteName = !empty($custSiteInfo['site_name']) ? $custSiteInfo['site_name'] : "Seo Panel";
-$controller->set('spTitle', "$siteName: Provides latest seo plugins to increase and track the performace your website");
-$controller->set('spDescription', "Its an open source software and also you can develop your own seo plugins for $siteName. Download new seo plugins and install into your $siteName software and increase your site perfomance.");
+$controller->set('spTitle', "$siteName: Provides latest seo plugins to increase and track the performance your website");
+$controller->set('spDescription', "Its an open source software and also you can develop your own seo plugins for $siteName. Download new seo plugins and install into your $siteName software and increase your site performance.");
 $controller->set('spKeywords', "$siteName plugins,latest seo plugins,download seo plugins,install seo plugins,develop seo plugins");
 
 if($_SERVER['REQUEST_METHOD'] == 'POST'){

--- a/settings.php
+++ b/settings.php
@@ -94,7 +94,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST'){
 				$mozCtrler = new MozController();
 				list($rankInfo, $logInfo) = $mozCtrler->__getMozRankInfo($urlList, $_GET['access_id'], $_GET['secret_key'], true);
 				
-				// if error occured
+                                // if error occurred
 				if (isset($logInfo['crawl_status']) && ($logInfo['crawl_status'] == 0)) {
 					print "<span class='error'>{$logInfo['log_message']}</span>";
 				} else {
@@ -116,7 +116,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST'){
 				$url = "https://moz.com";
 				list($rankInfo, $logInfo) = $pageSpeedCtrl->__getPageSpeedInfo($url, array(), $_GET['api_key'], true);
 				
-				// if error occured
+                                // if error occurred
 				if (isset($logInfo['crawl_status']) && ($logInfo['crawl_status'] == 0)) {
 					print "<span class='error'>{$logInfo['log_message']}</span>";
 				} else {
@@ -136,7 +136,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST'){
 		        $dfsCtrler = new DataForSEOController();
 		        $connResult = $dfsCtrler->__checkAPIConnection($_GET['api_login'], $_GET['api_password']);
 		        
-		        // if error occured
+                        // if error occurred
 		        if ($connResult['status'] == 'success') {
 		            print "<span class='success'>{$_SESSION['text']['label']['Success']}</span>";
 		            updateJsLocation("sp_dfs_balance",  $connResult['balance']);


### PR DESCRIPTION
## Summary
- fix typo in login page description
- fix several typos in SEO plugins page
- correct 'occurred' comments in settings
- fix spelling in installer scripts
- fix spelling in controllers and API docs

## Testing
- `codespell login.php seo-plugins.php settings.php install/db.class.php install/index.php controllers/api.ctrl.php controllers/directory.ctrl.php api/keyword.api.php controllers/seoplugins.ctrl.php controllers/proxy.ctrl.php | head`
- `php -l login.php`
- `php -l seo-plugins.php`
- `php -l settings.php`
- `php -l install/db.class.php`
- `php -l install/index.php`
- `php -l controllers/api.ctrl.php`
- `php -l controllers/directory.ctrl.php`
- `php -l api/keyword.api.php`
- `php -l controllers/seoplugins.ctrl.php`
- `php -l controllers/proxy.ctrl.php`


------
https://chatgpt.com/codex/tasks/task_e_6843adcbe2348323b82ca128b02c2a25